### PR TITLE
Revert bogus Flash updates

### DIFF
--- a/com.gamestarmechanic.gamestarmechanic.yaml
+++ b/com.gamestarmechanic.gamestarmechanic.yaml
@@ -66,8 +66,8 @@ modules:
       - type: extra-data
         filename: flash_player_ppapi_linux.x86_64.tar.gz
         url: https://web.archive.org/web/20210116212416if_/https://fpdownload.adobe.com/get/flashplayer/pdc/32.0.0.465/flash_player_ppapi_linux.x86_64.tar.gz
-        sha256: 184cfda9476c09798764f78744ace801737869dd30da8a81480b471a10f37c22
-        size: 11650
+        sha256: 99fcc780897be55bac7d11c0204ba7a3d5e7dc1f1aed75d5e7b5ad28c0b2ff5d
+        size: 9763881
     build-commands:
       - install apply_extra -Dt ${FLATPAK_DEST}/bin
   - name: wrapper

--- a/com.gamestarmechanic.gamestarmechanic.yaml
+++ b/com.gamestarmechanic.gamestarmechanic.yaml
@@ -66,8 +66,8 @@ modules:
       - type: extra-data
         filename: flash_player_ppapi_linux.x86_64.tar.gz
         url: https://web.archive.org/web/20210116212416if_/https://fpdownload.adobe.com/get/flashplayer/pdc/32.0.0.465/flash_player_ppapi_linux.x86_64.tar.gz
-        sha256: 866c7ac8b0f86379649b05bc4f2801fd5c3879c091a89b4b49513944d375ec15
-        size: 12252
+        sha256: 184cfda9476c09798764f78744ace801737869dd30da8a81480b471a10f37c22
+        size: 11650
     build-commands:
       - install apply_extra -Dt ${FLATPAK_DEST}/bin
   - name: wrapper

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+  "automerge-flathubbot-prs": false,
   "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
It seems archive.org has rate-limited something (GitHub) due to DDOS attacks and has been returning some error/text/etc so these flathubbot failures, and updates, are bogus. The file here is unchanging - literally static bytes from 2021 - so no update is ever needed. Revert the bad updates, and disable automerge of flathubbot PRs.